### PR TITLE
Add support for diff between 2 screenshots with Pixelmatch.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -13,9 +13,17 @@ crons:
 web:
   commands:
     start: "node index.js"
+  locations:
+    "/screenshots":
+        root: "screenshots"
+        scripts: false
+    "/diff":
+        root: "diff"
+        scripts: false
 
 mounts:
   "/pdfs": "shared:files/pdfs"
   "/screenshots": "shared:files/screenshots"
+  "/diff": "shared:files/diff"
 
 disk: 512

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "puppeteer": "^1.14.0",
     "express": "^4.16.4",
     "uuid": "^3.3.2",
-    "express-rate-limit": "^4.0.4"
+    "express-rate-limit": "^4.0.4",
+    "pixelmatch": "^5.2.1",
+    "pngjs": "^6.0.0"
   }
 }


### PR DESCRIPTION
This commit adds a new route `/compare/result` which takes as parameters:
* `img1`: the name of the first image (without the .png extension)
* `img2`: the name of the second image (without the .png extension)

The URL will store the diff image in the `/diff` folder, and send its URL back.